### PR TITLE
Add multiple `pattern` support on CLI

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -53,7 +53,13 @@ async function main() {
   } else if(argv.verbose) {
     logger._level = "verbose";
   }
-  if (argv.pattern) additionalConf.patterns = [argv.pattern];
+  if (argv.pattern) {
+    if (typeof argv.pattern === "string") {
+      additionalConf.patterns = [argv.pattern];
+    } else if (Array.isArray(argv.pattern)) {
+      additionalConf.patterns = argv.pattern;
+    }
+  }
   if (argv.prettier) additionalConf.prettier = true;
   if (argv.test) additionalConf.test = true;
   if (argv.normalizeRootImport) additionalConf.fileMapping!.normalizeRootImport = true;


### PR DESCRIPTION
Hi @Quramy, Thank you for very useful tool :dog2:

## What I did ?

If we set `pattern` using CLI, we can't specify multiple patterns.
So, I modified `cli.ts` to allow multiple` pattern`.

The following code is the result of a local testing.

### Before

```shell
$ node lib/cli.js -v --test -p 'packages/**/*.{ts,tsx}' -p '!node_modules/**/*' hoge fuga
project configurations:
{
  "patterns": [
    [
      "packages/**/*.{ts,tsx}",
      "!node_modules/**/*"
    ]
  ],
  "fileMapping": {
    "rootImport": [],
    "normalizeRootImport": false
  },
  "prettier": false,
  "test": true,
  "rootDir": "~/develop/github.com/wadackel/better-name"
}
(node:31979) UnhandledPromiseRejectionWarning: TypeError: pattern.charAt is not a function
    at GlobAll.globNext (~/develop/github.com/wadackel/better-name/node_modules/glob-all/glob-all.js:90:15)
    at GlobAll.run (~/develop/github.com/wadackel/better-name/node_modules/glob-all/glob-all.js:78:8)
    at globAll (~/develop/github.com/wadackel/better-name/node_modules/glob-all/glob-all.js:186:5)
    at ~/develop/github.com/wadackel/better-name/lib/project.js:42:13
    at new Promise (<anonymous>)
    at DefaultProject.getDocumentsList (~/develop/github.com/wadackel/better-name/lib/project.js:41:16)
    at DefaultProject.<anonymous> (~/develop/github.com/wadackel/better-name/lib/project.js:81:37)
    at Generator.next (<anonymous>)
    at ~/develop/github.com/wadackel/better-name/lib/project.js:8:71
    at new Promise (<anonymous>)
(node:31979) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block
, or by rejecting a promise which was not handled with .catch(). (rejection id: 2)
(node:31979) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node
.js process with a non-zero exit code.
```

### After

```shell
$ node lib/cli.js -v --test -p 'packages/**/*.{ts,tsx}' -p '!node_modules/**/*' hoge fuga
project configurations:
{
  "patterns": [
    "packages/**/*.{ts,tsx}",
    "!node_modules/**/*"
  ],
  "fileMapping": {
    "rootImport": [],
    "normalizeRootImport": false
  },
  "prettier": false,
  "test": true,
  "rootDir": "~/develop/github.com/wadackel/better-name"
}
```

```
$ node lib/cli.js -v --test -p 'packages/**/*.{ts,tsx}' hoge fuga
project configurations:
{
  "patterns": [
    "packages/**/*.{ts,tsx}"
  ],
  "fileMapping": {
    "rootImport": [],
    "normalizeRootImport": false
  },
  "prettier": false,
  "test": true,
  "rootDir": "~/develop/github.com/wadackel/better-name"
}
```
